### PR TITLE
Add bilingual READMEs and documentation

### DIFF
--- a/INSTALLATION_EN.md
+++ b/INSTALLATION_EN.md
@@ -1,0 +1,47 @@
+# Installation Documentation - Quick Stock Management for WooCommerce
+
+This document provides instructions for installing and activating the Quick Stock Management for WooCommerce plugin on your WordPress site.
+
+## Prerequisites
+
+Before installing this plugin, ensure the following are in place:
+
+*   **WordPress**: Version 5.8 or higher.
+*   **WooCommerce**: Version 6.0 or higher.
+*   **FTP/SFTP access or file manager**: To upload the plugin files to your server.
+
+## Installation Steps
+
+Follow these steps to install the plugin:
+
+1.  **Download the plugin**:
+    *   You should have a zip file containing the plugin (e.g., `quick-stock-management.zip`).
+
+2.  **Unzip the file**:
+    *   Unzip the `quick-stock-management.zip` file on your computer. This will create a folder named `quick-stock-management`.
+
+3.  **Upload the plugin folder**:
+    *   Connect to your WordPress site via FTP/SFTP or your hosting provider's file manager.
+    *   Navigate to the `wp-content/plugins/` directory.
+    *   Upload the `quick-stock-management` folder (the one you unzipped in the previous step) to this directory.
+
+4.  **Activate the plugin**:
+    *   Log in to your WordPress admin dashboard.
+    *   Go to `Plugins` > `Installed Plugins`.
+    *   Look for "Quick Stock Management for WooCommerce" in the list.
+    *   Click the `Activate` link under the plugin name.
+
+## Usage
+
+Once activated, the plugin will add a new submenu item under "Products" in your WordPress admin dashboard, titled "Quick Stock Management". Click on it to access the stock management interface.
+
+For more details on usage, please refer to the "User Guide".
+
+## Troubleshooting
+
+If you encounter problems during installation or use of the plugin:
+
+*   Verify that all prerequisites are met.
+*   Ensure that the files have been uploaded correctly to the right directory.
+*   Temporarily deactivate other plugins to check for conflicts.
+*   Contact support if the problem persists.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Quick Stock Management for WooCommerce
+
+Quick Stock Management for WooCommerce is a WordPress plugin that provides a simple interface to quickly update the stock status (in stock / out of stock) of your WooCommerce products.
+
+## Features
+
+*   Quickly toggle stock status for products.
+*   Visual feedback for stock status (In Stock / Out of Stock).
+*   Automatic sorting of products: in-stock items first, then out-of-stock, both alphabetically.
+*   AJAX-based updates for a smooth user experience without page reloads.
+
+## Installation
+
+1.  **Download the plugin**: You should have a zip file (e.g., `quick-stock-management.zip`).
+2.  **Unzip the file**: This will create a `quick-stock-management` folder.
+3.  **Upload the plugin folder**:
+    *   Connect to your WordPress site via FTP/SFTP or your host's file manager.
+    *   Navigate to the `wp-content/plugins/` directory.
+    *   Upload the `quick-stock-management` folder.
+4.  **Activate the plugin**:
+    *   Log in to your WordPress admin dashboard.
+    *   Go to `Plugins` > `Installed Plugins`.
+    *   Find "Quick Stock Management for WooCommerce" and click `Activate`.
+
+For more detailed installation instructions in French, please see [INSTALLATION.md](INSTALLATION.md).
+For English instructions, see [INSTALLATION_EN.md](INSTALLATION_EN.md).
+
+## Usage
+
+Once activated, the plugin adds a new submenu item under "Products" in your WordPress admin dashboard, called "Quick Stock Management".
+
+1.  **Access the Quick Stock Management Page**:
+    *   In the WordPress admin menu, go to `Products` > `Quick Stock Management`.
+2.  **Manage Stock**:
+    *   The interface lists your products.
+    *   Each product has a toggle switch to change its stock status.
+        *   Green (checked) means "In Stock".
+        *   Gray (unchecked) means "Out of Stock".
+    *   Click the toggle to update the status. Changes are saved automatically.
+
+For a more detailed user guide in French, please see [USER_GUIDE.md](USER_GUIDE.md).
+For an English guide, see [USER_GUIDE_EN.md](USER_GUIDE_EN.md).
+
+## Contributing
+
+Contributions are welcome! Please feel free to fork the repository, make your changes, and submit a pull request.
+
+## License
+
+This plugin is released under the [GPL v2 or later](https://www.gnu.org/licenses/gpl-2.0.html) license.

--- a/README_FR.md
+++ b/README_FR.md
@@ -1,0 +1,50 @@
+# Gestion Rapide de Stock pour WooCommerce
+
+Gestion Rapide de Stock pour WooCommerce (Quick Stock Management for WooCommerce) est une extension WordPress qui fournit une interface simple pour mettre à jour rapidement le statut de stock (en stock / en rupture de stock) de vos produits WooCommerce.
+
+## Fonctionnalités
+
+*   Basculez rapidement le statut de stock pour les produits.
+*   Retour visuel pour le statut du stock (En Stock / En Rupture de Stock).
+*   Tri automatique des produits : articles en stock en premier, puis ceux en rupture de stock, tous deux par ordre alphabétique.
+*   Mises à jour basées sur AJAX pour une expérience utilisateur fluide sans rechargement de page.
+
+## Installation
+
+1.  **Téléchargez l'extension** : Vous devriez avoir un fichier zip (par exemple, `quick-stock-management.zip`).
+2.  **Décompressez le fichier** : Cela créera un dossier `quick-stock-management`.
+3.  **Téléversez le dossier de l'extension** :
+    *   Connectez-vous à votre site WordPress via FTP/SFTP ou le gestionnaire de fichiers de votre hébergeur.
+    *   Naviguez jusqu'au répertoire `wp-content/plugins/`.
+    *   Téléversez le dossier `quick-stock-management`.
+4.  **Activez l'extension** :
+    *   Connectez-vous à votre tableau de bord d'administration WordPress.
+    *   Allez dans `Extensions` > `Extensions installées`.
+    *   Recherchez "Quick Stock Management for WooCommerce" et cliquez sur `Activer`.
+
+Pour des instructions d'installation plus détaillées en français, veuillez consulter [INSTALLATION.md](INSTALLATION.md).
+Pour les instructions en anglais, voir [INSTALLATION_EN.md](INSTALLATION_EN.md).
+
+## Utilisation
+
+Une fois activée, l'extension ajoute un nouvel élément de sous-menu sous "Produits" dans votre tableau de bord d'administration WordPress, intitulé "Gestion rapide du stock".
+
+1.  **Accéder à la page de Gestion rapide du stock** :
+    *   Dans le menu d'administration de WordPress, allez à `Produits` > `Gestion rapide du stock`.
+2.  **Gérer les stocks** :
+    *   L'interface liste vos produits.
+    *   Chaque produit dispose d'un interrupteur pour modifier son statut de stock.
+        *   Vert (coché) signifie "En stock".
+        *   Gris (non coché) signifie "En rupture de stock".
+    *   Cliquez sur l'interrupteur pour mettre à jour le statut. Les modifications sont enregistrées automatiquement.
+
+Pour un guide utilisateur plus détaillé en français, veuillez consulter [USER_GUIDE.md](USER_GUIDE.md).
+Pour le guide en anglais, voir [USER_GUIDE_EN.md](USER_GUIDE_EN.md).
+
+## Contribuer
+
+Les contributions sont les bienvenues ! N'hésitez pas à forker le dépôt, à apporter vos modifications et à soumettre une pull request.
+
+## Licence
+
+Cette extension est publiée sous la licence [GPL v2 ou ultérieure](https://www.gnu.org/licenses/gpl-2.0.html).

--- a/USER_GUIDE_EN.md
+++ b/USER_GUIDE_EN.md
@@ -1,0 +1,50 @@
+# User Guide - Quick Stock Management for WooCommerce
+
+This guide will help you use the Quick Stock Management interface for WooCommerce, allowing you to quickly change the stock status of your products.
+
+## Accessing the Quick Stock Management Page
+
+1.  Log in to your WordPress admin dashboard.
+2.  In the left-hand menu, hover over "Products".
+3.  Click on "Quick Stock Management".
+
+You will arrive at a page similar to this:
+
+![Quick Stock Management Interface Screenshot](/home/ubuntu/qsm_interface_screenshot_placeholder.png)
+*(Note: The image path above is a placeholder and might need adjustment if the image is stored within the plugin's assets folder, e.g., `../assets/images/qsm_interface_screenshot.png` or a similar relative path if the image is indeed part of the plugin package.)*
+
+## Understanding the Interface
+
+The interface is designed to be simple and intuitive:
+
+*   **Product Name**: The first column displays the name of each product.
+*   **Stock Status**: The second column contains a toggle switch and a visual badge indicating the current stock status.
+    *   **Green switch (checked)**: The product is in stock (`instock`).
+    *   **Gray switch (unchecked)**: The product is out of stock (`outofstock`).
+    *   **Green "In Stock" badge**: Visual confirmation that the product is in stock.
+    *   **Red "Out of Stock" badge**: Visual confirmation that the product is out of stock.
+
+## Managing Product Stock
+
+To change the stock status of a product:
+
+1.  **Locate the product** you want to modify in the list.
+2.  **Click the toggle switch** next to the product name.
+    *   If the product is in stock, click to set it to out of stock.
+    *   If the product is out of stock, click to set it to in stock.
+
+### Visual Feedback
+
+*   While the change is being saved, a small loading indicator (spinner) will appear next to the switch.
+*   Once the update is successful, the status badge will change color and text to reflect the new status.
+
+### Automatic Sorting
+
+The product list automatically sorts to display in-stock products first, followed by out-of-stock products. Within each group, products are sorted alphabetically.
+
+## Quick Troubleshooting
+
+*   **Status not changing?** Check your internet connection. If the problem persists, reload the page.
+*   **Error message?** Read the message to understand the issue. It might be a permissions problem or a server error.
+
+If you have other questions or encounter problems, please consult the installation documentation or contact your system administrator.


### PR DESCRIPTION
This commit introduces comprehensive documentation in both English and French.

- Created `README.md` (English) as the primary README, including plugin description, installation, and usage summaries.
- Created `README_FR.md` (French) as a translation of the primary README.
- Translated `INSTALLATION.md` (French) to `INSTALLATION_EN.md` (English).
- Translated `USER_GUIDE.md` (French) to `USER_GUIDE_EN.md` (English).
- Updated both `README.md` and `README_FR.md` to link to all four detailed guides (French and English versions of installation and user guides).

This enhances your accessibility by providing documentation in two major languages.